### PR TITLE
Revert "Bump activesupport from 5.2.3 to 6.0.3.2"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,15 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.3.2)
+    activesupport (5.2.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-      zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     colorator (1.1.0)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.5)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
@@ -58,7 +57,7 @@ GEM
       ruby_dep (~> 1.2)
     mercenary (0.3.6)
     mini_portile2 (2.4.0)
-    minitest (5.14.1)
+    minitest (5.11.3)
     multipart-post (2.0.0)
     nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
@@ -98,9 +97,8 @@ GEM
       faraday (~> 0.8, < 1.0)
     thread_safe (0.3.6)
     titlecase (0.1.1)
-    tzinfo (1.2.7)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    zeitwerk (2.3.1)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Reverts cubarco/cubarco.github.io#3